### PR TITLE
Fixed show/hide keyboard blocks

### DIFF
--- a/Pod/Classes/KeyboardAdjuster.swift
+++ b/Pod/Classes/KeyboardAdjuster.swift
@@ -37,10 +37,6 @@ private extension UIViewController {
                 return
         }
 
-        if let block = sender.object as? (() -> Void) {
-            block()
-        }
-
         var curveAnimationOption: UIViewAnimationOptions
         switch curve {
         case .easeIn:
@@ -127,13 +123,26 @@ extension KeyboardAdjuster where Self: UIViewController {
      - copyright: ©2016 Lionheart Software LLC
      - date: February 18, 2016
      */
-    public func activateKeyboardAdjuster(_ showBlock: AnyObject?, hideBlock: AnyObject?) {
+    public func activateKeyboardAdjuster(_ showBlock: (()->())?, hideBlock: (()->())?) {
         // Activate the bottom constraint.
         keyboardAdjusterConstraint?.isActive = true
 
         let notificationCenter = NotificationCenter.default
-        notificationCenter.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: hideBlock)
-        notificationCenter.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: showBlock)
+        notificationCenter.addObserver(forName: NSNotification.Name.UIKeyboardWillHide, object: nil, queue: OperationQueue.main, using: {
+            [weak self] notification in
+            
+            self?.keyboardWillHide(notification)
+            
+            hideBlock?()
+        })
+        
+        notificationCenter.addObserver(forName: NSNotification.Name.UIKeyboardWillShow, object: nil, queue: OperationQueue.main, using: {
+            [weak self] notification in
+            
+            self?.keyboardWillShow(notification)
+            
+            showBlock?()
+        })
 
         guard let viewA = keyboardAdjusterConstraint?.firstItem as? UIView,
             let viewB = keyboardAdjusterConstraint?.secondItem as? UIView else {


### PR DESCRIPTION
This pull request fixes the show/hide keyboard blocks.

If you attempted to use these blocks previously they prevented the keyboard notifications (willHide, willShow) from working. Because they were being set into the `object` parameter for NotificationCenter addObserver(observer:selector:name:object:). This parameter is intended to do the following:

"The object whose notifications the observer wants to receive; that is, only notifications sent by this sender are delivered to the observer."

This does not provide the intended effect. Instead the addObserver(forName:object:queue:using:) method is used and the user's blocks are bound into the supplied closure. I also moved the blocks to be called after the internal handling of the notification, as it might be more helpful to have your custom block called after the constraints and layout are modified rather than before.