### PR TITLE
Docs for Safe Area Layout Guides result in unsatisfiable constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,20 @@ pod "KeyboardAdjuster", "~> 3"
      func viewDidLoad() {
          super.viewDidLoad()
 
+         var bottomBoundaryConstraint: NSLayoutConstraint
+         var keyboardTopConstraint: NSLayoutConstraint
+
          if #available(iOS 11, *) {
-             tableView.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+             bottomBoundaryConstraint = tableView.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor)
          } else {
-             tableView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor).isActive = true
+             bottomBoundaryConstraint = tableView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
          }
 
-         tableView.bottomAnchor.constraint(greaterThanOrEqualTo: keyboardLayoutGuide.topAnchor).isActive = true
+         bottomBoundaryConstraint.isActive = true
+
+         keyboardTopConstraint = tableView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor)
+         keyboardTopConstraint.priority = UILayoutPriority(rawValue: 999)
+         keyboardTopConstraint.isActive = true
      }
      ```
    </details>


### PR DESCRIPTION
This repo has a test target you can build and run, "TestApplication." The docs list an alternative approach for handling `safeAreaLayoutGuide`.

If you make the changes listed in that code example to TestApplication and nothing else, it results in unsatisfiable constraints.

```
2018-06-10 18:39:20.523973-0700 TestApplication[80159:3227789] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x60c00008f280 UITableView:0x7fd91784fe00.bottom <= UILayoutGuide:0x60c0001af260'UIViewSafeAreaLayoutGuide'.bottom   (active)>",
    "<NSLayoutConstraint:0x60c00008f780 V:[UIView:0x7fd91a801460]-(0)-[KeyboardAdjuster.KeyboardLayoutGuide:0x60c0001c2760'KeyboardLayoutGuide']   (active)>",
    "<NSLayoutConstraint:0x60c00008fb40 UITableView:0x7fd91784fe00.bottom >= KeyboardAdjuster.KeyboardLayoutGuide:0x60c0001c2760'KeyboardLayoutGuide'.top   (active)>",
    "<NSLayoutConstraint:0x60c00008edd0 'UIViewSafeAreaLayoutGuide-bottom' V:[UILayoutGuide:0x60c0001af260'UIViewSafeAreaLayoutGuide']-(34)-|   (active, names: '|':UIView:0x7fd91a801460 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60c00008f780 V:[UIView:0x7fd91a801460]-(0)-[KeyboardAdjuster.KeyboardLayoutGuide:0x60c0001c2760'KeyboardLayoutGuide']   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKit/UIView.h> may also be helpful.
```

This PR reduces the priority of the top keyboard constraint to produce the intended behavior.